### PR TITLE
feat: 实现个人中心页面功能

### DIFF
--- a/app/personal/page.tsx
+++ b/app/personal/page.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useAuth } from '@/components/providers/auth-provider';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Navbar from '@/components/navbar';
+import ProfileCard from '@/components/personal/ProfileCard';
+import PersonalInfo from '@/components/personal/PersonalInfo';
+import ActionButtons from '@/components/personal/ActionButtons';
+import TrainingSection from '@/components/personal/TrainingSection';
+
+interface TrainingItem {
+  id: string;
+  name: string;
+  type: string;
+  dataCount: number;
+  status: 'completed' | 'training' | 'failed';
+  icon: string;
+  date: string;
+}
+
+export default function PersonalCentre() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [userStats, setUserStats] = useState({
+    digitalHumans: 0,
+    conversations: 0,
+    trainingSessions: 0
+  });
+  const [trainingData, setTrainingData] = useState<TrainingItem[]>([]);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  // 这里将来可以从API获取用户的实际数据
+  // 目前先显示空状态或者可以根据需要添加一些示例数据进行测试
+  useEffect(() => {
+    if (user) {
+      // 示例：如果需要测试有数据的状态，可以取消注释下面的代码
+      // setUserStats({
+      //   digitalHumans: 12,
+      //   conversations: 48,
+      //   trainingSessions: 156
+      // });
+      // setTrainingData([
+      //   {
+      //     id: '1',
+      //     name: '口才训练助手 - 演讲技巧优化',
+      //     type: '对话训练',
+      //     dataCount: 5000,
+      //     status: 'completed',
+      //     icon: '🎯',
+      //     date: '2天前'
+      //   },
+      //   // 更多数据...
+      // ]);
+    }
+  }, [user]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#0A1628] flex items-center justify-center">
+        <div className="text-[#F5F5F5]">加载中...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0A1628] relative overflow-x-hidden">
+      <div 
+        className="fixed inset-0 pointer-events-none"
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(0, 217, 255, 0.03) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0, 217, 255, 0.03) 1px, transparent 1px)
+          `,
+          backgroundSize: '50px 50px'
+        }}
+      />
+      
+      <Navbar />
+      
+      <div className="relative z-10 max-w-6xl mx-auto px-8 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
+          <div className="lg:col-span-1">
+            <ProfileCard 
+              user={user} 
+              digitalHumans={userStats.digitalHumans}
+              conversations={userStats.conversations}
+              trainingSessions={userStats.trainingSessions}
+            />
+          </div>
+          <div className="lg:col-span-2">
+            <PersonalInfo user={user} />
+          </div>
+        </div>
+
+        <ActionButtons />
+        
+        <TrainingSection trainingData={trainingData} />
+      </div>
+    </div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -2,12 +2,14 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Menu } from 'lucide-react';
 import { useAuth } from '@/components/providers/auth-provider';
 
 export default function Navbar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { user, logout } = useAuth();
+  const pathname = usePathname();
 
   return (
     <nav className="sticky top-0 z-[100] backdrop-blur-[20px]" style={{
@@ -24,25 +26,52 @@ export default function Navbar() {
             <li>
               <Link 
                 href="/" 
-                className="text-[var(--text-secondary)] hover:text-[var(--accent-primary)] transition-colors relative"
+                className={`transition-colors relative ${
+                  pathname === '/' 
+                    ? 'text-[var(--accent-primary)]' 
+                    : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                }`}
               >
                 首页
+                {pathname === '/' && (
+                  <div className="absolute -bottom-2 left-0 right-0 h-0.5" style={{
+                    background: 'var(--accent-gradient)'
+                  }} />
+                )}
               </Link>
             </li>
             <li>
               <Link 
                 href="/chat" 
-                className="text-[var(--text-secondary)] hover:text-[var(--accent-primary)] transition-colors"
+                className={`transition-colors relative ${
+                  pathname === '/chat' 
+                    ? 'text-[var(--accent-primary)]' 
+                    : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                }`}
               >
                 会话
+                {pathname === '/chat' && (
+                  <div className="absolute -bottom-2 left-0 right-0 h-0.5" style={{
+                    background: 'var(--accent-gradient)'
+                  }} />
+                )}
               </Link>
             </li>
             <li>
               <Link 
-                href="/profile" 
-                className="text-[var(--text-secondary)] hover:text-[var(--accent-primary)] transition-colors"
+                href="/personal" 
+                className={`transition-colors relative ${
+                  pathname === '/personal' 
+                    ? 'text-[var(--accent-primary)]' 
+                    : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                }`}
               >
                 个人中心
+                {pathname === '/personal' && (
+                  <div className="absolute -bottom-2 left-0 right-0 h-0.5" style={{
+                    background: 'var(--accent-gradient)'
+                  }} />
+                )}
               </Link>
             </li>
           </ul>
@@ -87,7 +116,11 @@ export default function Navbar() {
               <li>
                 <Link 
                   href="/" 
-                  className="block text-[var(--text-secondary)] hover:text-[var(--accent-primary)]"
+                  className={`block ${
+                    pathname === '/' 
+                      ? 'text-[var(--accent-primary)]' 
+                      : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                  }`}
                 >
                   首页
                 </Link>
@@ -95,15 +128,23 @@ export default function Navbar() {
               <li>
                 <Link 
                   href="/chat" 
-                  className="block text-[var(--text-secondary)] hover:text-[var(--accent-primary)]"
+                  className={`block ${
+                    pathname === '/chat' 
+                      ? 'text-[var(--accent-primary)]' 
+                      : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                  }`}
                 >
                   会话
                 </Link>
               </li>
               <li>
                 <Link 
-                  href="/profile" 
-                  className="block text-[var(--text-secondary)] hover:text-[var(--accent-primary)]"
+                  href="/personal" 
+                  className={`block ${
+                    pathname === '/personal' 
+                      ? 'text-[var(--accent-primary)]' 
+                      : 'text-[var(--text-secondary)] hover:text-[var(--accent-primary)]'
+                  }`}
                 >
                   个人中心
                 </Link>

--- a/components/personal/ActionButtons.tsx
+++ b/components/personal/ActionButtons.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function ActionButtons() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+      <button className="group relative overflow-hidden font-medium py-3 px-6 rounded-lg border border-[rgba(255,255,255,0.1)] bg-transparent text-[#F5F5F5] backdrop-blur-[10px] text-center transition-all duration-300 hover:border-[#00D9FF] hover:shadow-[0_0_10px_rgba(0,217,255,0.3)] hover:transform hover:-translate-y-1">
+        <span className="relative z-10">训练</span>
+      </button>
+
+      <button className="group relative overflow-hidden font-medium py-3 px-6 rounded-lg border-transparent bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] text-[#0A1628] text-center transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-[0_10px_15px_rgba(0,217,255,0.15),0_0_20px_rgba(0,217,255,0.4)]">
+        <span className="relative z-10 text-2xl">➕</span>
+      </button>
+
+      <button className="group relative overflow-hidden font-medium py-3 px-6 rounded-lg border border-[rgba(255,255,255,0.1)] bg-transparent text-[#F5F5F5] backdrop-blur-[10px] text-center transition-all duration-300 hover:border-[#00D9FF] hover:shadow-[0_0_10px_rgba(0,217,255,0.3)] hover:transform hover:-translate-y-1">
+        <span className="relative z-10">会话</span>
+      </button>
+    </div>
+  );
+}

--- a/components/personal/PersonalInfo.tsx
+++ b/components/personal/PersonalInfo.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { User } from '@/lib/types';
+
+interface PersonalInfoProps {
+  user: User;
+}
+
+export default function PersonalInfo({ user }: PersonalInfoProps) {
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    });
+  };
+
+  const formatDateTime = (dateString: string) => {
+    return new Date(dateString).toLocaleString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+
+  return (
+    <div className="bg-[#16213E] border border-[rgba(255,255,255,0.1)] rounded-2xl p-8 backdrop-blur-xl shadow-[0_10px_15px_rgba(0,217,255,0.15)]">
+      <h3 className="text-xl font-semibold mb-6 text-[#F5F5F5] flex items-center gap-2">
+        <div className="w-1 h-5 bg-gradient-to-b from-[#00D9FF] to-[#7B68EE] rounded-full" />
+        个人信息
+      </h3>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="flex justify-between items-center p-4 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg transition-all duration-300 hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF]">
+          <span className="text-[#B8BCC8] text-sm">用户名</span>
+          <span className="text-[#F5F5F5] font-medium">{user.username}</span>
+        </div>
+
+        <div className="flex justify-between items-center p-4 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg transition-all duration-300 hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF]">
+          <span className="text-[#B8BCC8] text-sm">用户ID</span>
+          <span className="text-[#F5F5F5] font-medium">{user.id}</span>
+        </div>
+
+        <div className="flex justify-between items-center p-4 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg transition-all duration-300 hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF]">
+          <span className="text-[#B8BCC8] text-sm">注册时间</span>
+          <span className="text-[#F5F5F5] font-medium">{formatDate(user.created_at)}</span>
+        </div>
+
+        <div className="flex justify-between items-center p-4 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg transition-all duration-300 hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF]">
+          <span className="text-[#B8BCC8] text-sm">邮箱</span>
+          <span className="text-[#F5F5F5] font-medium">{user.email}</span>
+        </div>
+
+        <div className="flex justify-between items-center p-4 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-lg transition-all duration-300 hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF]">
+          <span className="text-[#B8BCC8] text-sm">最后登录</span>
+          <span className="text-[#F5F5F5] font-medium">{formatDateTime(user.updated_at)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/personal/ProfileCard.tsx
+++ b/components/personal/ProfileCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { User } from '@/lib/types';
+import StatsGrid from './StatsGrid';
+
+interface ProfileCardProps {
+  user: User;
+  digitalHumans?: number;
+  conversations?: number;
+  trainingSessions?: number;
+}
+
+export default function ProfileCard({ user, digitalHumans = 0, conversations = 0, trainingSessions = 0 }: ProfileCardProps) {
+  const getUserInitials = (user: User) => {
+    if (user.full_name) {
+      return user.full_name
+        .split(' ')
+        .map(name => name[0])
+        .slice(0, 2)
+        .join('')
+        .toUpperCase();
+    }
+    return user.username.slice(0, 2).toUpperCase();
+  };
+
+  return (
+    <div className="bg-[#16213E] border border-[rgba(255,255,255,0.1)] rounded-2xl p-8 backdrop-blur-xl shadow-[0_10px_15px_rgba(0,217,255,0.15)] relative overflow-hidden transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-[0_20px_25px_rgba(0,217,255,0.2),0_0_10px_rgba(0,217,255,0.3)] hover:border-[rgba(255,255,255,0.2)]">
+      <div 
+        className="absolute inset-[-2px] rounded-2xl p-[2px] opacity-0 transition-opacity duration-300 hover:opacity-100"
+        style={{
+          background: 'linear-gradient(135deg, #00D9FF 0%, #7B68EE 100%)',
+          WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+          WebkitMaskComposite: 'xor',
+          maskComposite: 'exclude'
+        }}
+      />
+      
+      <div className="text-center mb-8">
+        <div className="relative inline-block mb-4">
+          <div className="w-32 h-32 rounded-full bg-gradient-to-br from-[#00D9FF] to-[#7B68EE] border-3 border-[#00D9FF] flex items-center justify-center text-3xl font-semibold text-[#0A1628] relative overflow-hidden shadow-[0_0_20px_rgba(0,217,255,0.4)]">
+            <span>{getUserInitials(user)}</span>
+            <div 
+              className="absolute inset-[-50%] opacity-30 animate-spin"
+              style={{
+                background: 'conic-gradient(from 0deg, transparent, #00D9FF, transparent 30%)',
+                animationDuration: '3s'
+              }}
+            />
+          </div>
+        </div>
+        <h2 className="text-2xl font-semibold text-[#F5F5F5] mb-2">
+          {user.full_name || user.username}
+        </h2>
+        <p className="text-[#6C7293] text-sm mb-4">
+          ID: {user.id}
+        </p>
+      </div>
+
+      <StatsGrid 
+        digitalHumans={digitalHumans}
+        conversations={conversations}
+        trainingSessions={trainingSessions}
+      />
+    </div>
+  );
+}

--- a/components/personal/StatsGrid.tsx
+++ b/components/personal/StatsGrid.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+interface StatsGridProps {
+  digitalHumans: number;
+  conversations: number;
+  trainingSessions: number;
+}
+
+export default function StatsGrid({ digitalHumans, conversations, trainingSessions }: StatsGridProps) {
+  return (
+    <div className="grid grid-cols-3 gap-6">
+      <div className="text-center p-4 bg-[rgba(22,33,62,0.8)] rounded-2xl border border-[rgba(255,255,255,0.1)] transition-all duration-300 hover:bg-[rgba(22,33,62,0.9)] hover:border-[#00D9FF] hover:transform hover:-translate-y-1 hover:shadow-[0_4px_6px_rgba(0,217,255,0.1)] relative overflow-hidden min-h-[100px] flex flex-col justify-center items-center">
+        <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] opacity-0 transition-opacity duration-300 hover:opacity-100" />
+        <div className="text-3xl font-bold text-[#00D9FF] mb-1 leading-tight">
+          {digitalHumans}
+        </div>
+        <div className="text-sm text-[#B8BCC8] font-normal whitespace-nowrap">
+          数字人
+        </div>
+      </div>
+
+      <div className="text-center p-4 bg-[rgba(22,33,62,0.8)] rounded-2xl border border-[rgba(255,255,255,0.1)] transition-all duration-300 hover:bg-[rgba(22,33,62,0.9)] hover:border-[#00D9FF] hover:transform hover:-translate-y-1 hover:shadow-[0_4px_6px_rgba(0,217,255,0.1)] relative overflow-hidden min-h-[100px] flex flex-col justify-center items-center">
+        <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] opacity-0 transition-opacity duration-300 hover:opacity-100" />
+        <div className="text-3xl font-bold text-[#00D9FF] mb-1 leading-tight">
+          {conversations}
+        </div>
+        <div className="text-sm text-[#B8BCC8] font-normal whitespace-nowrap">
+          总对话数
+        </div>
+      </div>
+
+      <div className="text-center p-4 bg-[rgba(22,33,62,0.8)] rounded-2xl border border-[rgba(255,255,255,0.1)] transition-all duration-300 hover:bg-[rgba(22,33,62,0.9)] hover:border-[#00D9FF] hover:transform hover:-translate-y-1 hover:shadow-[0_4px_6px_rgba(0,217,255,0.1)] relative overflow-hidden min-h-[100px] flex flex-col justify-center items-center">
+        <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] opacity-0 transition-opacity duration-300 hover:opacity-100" />
+        <div className="text-3xl font-bold text-[#00D9FF] mb-1 leading-tight">
+          {trainingSessions}
+        </div>
+        <div className="text-sm text-[#B8BCC8] font-normal whitespace-nowrap">
+          训练次数
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/personal/TrainingSection.tsx
+++ b/components/personal/TrainingSection.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import Link from 'next/link';
+
+interface TrainingItem {
+  id: string;
+  name: string;
+  type: string;
+  dataCount: number;
+  status: 'completed' | 'training' | 'failed';
+  icon: string;
+  date: string;
+}
+
+interface TrainingSectionProps {
+  trainingData?: TrainingItem[];
+}
+
+const getStatusColor = (status: TrainingItem['status']) => {
+  switch (status) {
+    case 'completed':
+      return 'bg-[#00F5A0]';
+    case 'training':
+      return 'bg-[#F7B731]';
+    case 'failed':
+      return 'bg-[#EE5A6F]';
+    default:
+      return 'bg-[#00F5A0]';
+  }
+};
+
+const getStatusText = (status: TrainingItem['status']) => {
+  switch (status) {
+    case 'completed':
+      return '已完成';
+    case 'training':
+      return '训练中';
+    case 'failed':
+      return '失败';
+    default:
+      return '已完成';
+  }
+};
+
+export default function TrainingSection({ trainingData = [] }: TrainingSectionProps) {
+  const hasTraining = trainingData.length > 0;
+
+  return (
+    <div className="bg-[#16213E] border border-[rgba(255,255,255,0.1)] rounded-2xl p-8 backdrop-blur-xl shadow-[0_10px_15px_rgba(0,217,255,0.15)]">
+      {hasTraining ? (
+        <>
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-xl font-semibold text-[#F5F5F5] flex items-center gap-2">
+              <div className="w-1 h-5 bg-gradient-to-b from-[#00D9FF] to-[#7B68EE] rounded-full" />
+              我的训练
+            </h3>
+            
+            <Link 
+              href="#" 
+              className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] text-[#0A1628] rounded-md text-sm font-medium transition-all duration-300 shadow-[0_4px_6px_rgba(0,217,255,0.1)] hover:transform hover:-translate-y-1 hover:shadow-[0_10px_15px_rgba(0,217,255,0.15),0_0_20px_rgba(0,217,255,0.4)]"
+            >
+              <span>➕</span>
+              <span>新建训练</span>
+            </Link>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            {trainingData.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between p-6 bg-[rgba(0,217,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-xl transition-all duration-300 cursor-pointer hover:bg-[rgba(0,217,255,0.1)] hover:border-[#00D9FF] hover:transform hover:translate-x-1"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-10 h-10 bg-[rgba(0,217,255,0.1)] rounded-lg flex items-center justify-center text-xl">
+                    {item.icon}
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <div className="font-medium text-[#F5F5F5]">
+                      {item.name}
+                    </div>
+                    <div className="text-sm text-[#B8BCC8]">
+                      {item.type} · {item.dataCount.toLocaleString()}条数据
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="flex items-center gap-2 text-sm">
+                    <div className={`w-2 h-2 rounded-full ${getStatusColor(item.status)}`} />
+                    <span className="text-[#F5F5F5]">{getStatusText(item.status)}</span>
+                  </div>
+                  <div className="text-sm text-[#6C7293]">
+                    {item.date}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <h3 className="text-xl font-semibold mb-6 text-[#F5F5F5] flex items-center gap-2">
+            <div className="w-1 h-5 bg-gradient-to-b from-[#00D9FF] to-[#7B68EE] rounded-full" />
+            我的数字人
+          </h3>
+          
+          <div className="text-center py-16 text-[#6C7293]">
+            <div className="text-5xl mb-4 opacity-30">🤖</div>
+            <p className="mb-6">您还没有创建数字人</p>
+            <Link 
+              href="#" 
+              className="inline-flex items-center gap-2 mt-6 px-8 py-3 bg-gradient-to-r from-[#00D9FF] to-[#7B68EE] text-[#0A1628] rounded-lg font-medium transition-all duration-300 shadow-[0_4px_6px_rgba(0,217,255,0.1)] hover:transform hover:-translate-y-1 hover:shadow-[0_10px_15px_rgba(0,217,255,0.15),0_0_20px_rgba(0,217,255,0.4)]"
+            >
+              <span>➕</span>
+              <span>创建数字人</span>
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- 创建个人中心页面路由 (/personal)
- 实现ProfileCard组件显示用户头像和统计数据
- 实现PersonalInfo组件显示用户详细信息
- 实现TrainingSection组件支持空状态和训练记录显示
- 修复导航栏个人中心链接并添加路径高亮
- 优化UI显示：增大头像尺寸、统计数据居中、邮箱完整显示
- 移除不必要的用户状态字段以符合设计文档

🤖 Generated with [Claude Code](https://claude.ai/code)